### PR TITLE
Enable incident file attachments

### DIFF
--- a/app/Http/Controllers/IncidentController.php
+++ b/app/Http/Controllers/IncidentController.php
@@ -60,9 +60,17 @@ class IncidentController extends Controller
             'location' => 'required',
             'date' => 'required|date',
             'user_id' => 'required|exists:users,id',
+            'files.*' => 'file|mimes:jpg,jpeg,png,pdf,doc,docx|max:2048',
         ]);
 
-        Incident::create($request->all());
+        $incident = Incident::create($request->all());
+
+        if ($request->hasFile('files')) {
+            foreach ($request->file('files') as $file) {
+                $path = $file->store('incidents', 'public');
+                $incident->files()->create(['path' => $path]);
+            }
+        }
 
         return redirect()->route('incidents.index')
             ->with('success', 'Incident created successfully.');
@@ -73,6 +81,8 @@ class IncidentController extends Controller
      */
     public function show(Incident $incident)
     {
+        $incident->load('files');
+
         return view('incidents.show', compact('incident'));
     }
 
@@ -96,9 +106,17 @@ class IncidentController extends Controller
             'location' => 'required',
             'date' => 'required|date',
             'user_id' => 'required|exists:users,id',
+            'files.*' => 'file|mimes:jpg,jpeg,png,pdf,doc,docx|max:2048',
         ]);
 
         $incident->update($request->all());
+
+        if ($request->hasFile('files')) {
+            foreach ($request->file('files') as $file) {
+                $path = $file->store('incidents', 'public');
+                $incident->files()->create(['path' => $path]);
+            }
+        }
 
         return redirect()->route('incidents.index')
             ->with('success', 'Incident updated successfully');

--- a/app/Models/Incident.php
+++ b/app/Models/Incident.php
@@ -4,6 +4,8 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use App\Models\IncidentFile;
 
 class Incident extends Model
 {
@@ -22,5 +24,10 @@ class Incident extends Model
     public function user()
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function files(): HasMany
+    {
+        return $this->hasMany(IncidentFile::class);
     }
 }

--- a/app/Models/IncidentFile.php
+++ b/app/Models/IncidentFile.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class IncidentFile extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'path',
+        'incident_id',
+    ];
+
+    public function incident()
+    {
+        return $this->belongsTo(Incident::class);
+    }
+}

--- a/database/migrations/2025_07_09_090000_create_incident_files_table.php
+++ b/database/migrations/2025_07_09_090000_create_incident_files_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('incident_files', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('incident_id')->constrained()->onDelete('cascade');
+            $table->string('path');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('incident_files');
+    }
+};

--- a/resources/views/incidents/create.blade.php
+++ b/resources/views/incidents/create.blade.php
@@ -9,7 +9,7 @@
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
                 <div class="p-6 lg:p-8 bg-white border-b border-gray-200">
-                    <form action="{{ route('incidents.store') }}" method="POST">
+                    <form action="{{ route('incidents.store') }}" method="POST" enctype="multipart/form-data">
                         @csrf
                         <div class="grid grid-cols-1 gap-6">
                             <div>
@@ -35,6 +35,10 @@
                                         <option value="{{ $user->id }}">{{ $user->name }}</option>
                                     @endforeach
                                 </select>
+                            </div>
+                            <div>
+                                <label for="files" class="block font-medium text-sm text-gray-700">{{ __('Files') }}</label>
+                                <input type="file" name="files[]" id="files" multiple class="form-input rounded-md shadow-sm mt-1 block w-full" />
                             </div>
                             <div class="flex items-center justify-end mt-4">
                                 <button type="submit" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">

--- a/resources/views/incidents/edit.blade.php
+++ b/resources/views/incidents/edit.blade.php
@@ -9,7 +9,7 @@
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white overflow-hidden shadow-xl sm:rounded-lg">
                 <div class="p-6 lg:p-8 bg-white border-b border-gray-200">
-                    <form action="{{ route('incidents.update', $incident->id) }}" method="POST">
+                    <form action="{{ route('incidents.update', $incident->id) }}" method="POST" enctype="multipart/form-data">
                         @csrf
                         @method('PUT')
                         <div class="grid grid-cols-1 gap-6">
@@ -36,6 +36,10 @@
                                         <option value="{{ $user->id }}" @if($user->id == $incident->user_id) selected @endif>{{ $user->name }}</option>
                                     @endforeach
                                 </select>
+                            </div>
+                            <div>
+                                <label for="files" class="block font-medium text-sm text-gray-700">{{ __('Files') }}</label>
+                                <input type="file" name="files[]" id="files" multiple class="form-input rounded-md shadow-sm mt-1 block w-full" />
                             </div>
                             <div class="flex items-center justify-end mt-4">
                                 <button type="submit" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">

--- a/resources/views/incidents/show.blade.php
+++ b/resources/views/incidents/show.blade.php
@@ -18,6 +18,22 @@
                         <p><strong>{{ __('Location') }}:</strong> {{ $incident->location }}</p>
                         <p><strong>{{ __('Date') }}:</strong> {{ $incident->date }}</p>
                         <p><strong>{{ __('Officer') }}:</strong> {{ $incident->user->name }}</p>
+                        @php use Illuminate\Support\Facades\Storage; @endphp
+                        @if ($incident->files->isNotEmpty())
+                            <div class="mt-4">
+                                <h3 class="font-medium">{{ __('Files') }}</h3>
+                                <div class="mt-2 grid grid-cols-1 md:grid-cols-3 gap-4">
+                                    @foreach ($incident->files as $file)
+                                        @php $ext = pathinfo($file->path, PATHINFO_EXTENSION); @endphp
+                                        @if (in_array(strtolower($ext), ['jpg','jpeg','png','gif']))
+                                            <img src="{{ Storage::url($file->path) }}" class="max-w-full h-auto" />
+                                        @else
+                                            <a href="{{ Storage::url($file->path) }}" class="text-blue-500 underline" target="_blank">{{ basename($file->path) }}</a>
+                                        @endif
+                                    @endforeach
+                                </div>
+                            </div>
+                        @endif
                     </div>
 
                     <div class="mt-6 flex items-center justify-end">


### PR DESCRIPTION
## Summary
- store uploaded files related to incidents
- expose relation on Incident model
- handle uploads in controller
- allow file uploads in incident forms
- show uploaded files in incident details

## Testing
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e7a57d04c83209d650b663f964ff4